### PR TITLE
core: Fix linting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,11 @@ Some code:
             State                      *string `mapstructure:"state"`
         }
 
-1. Implement the `ApiCall` interface for the command. The `URLPathFunc` argument makes use of the Name and Resource Group Name attributes to construct a URL, and the `ApiInfo` method determines the HTTP Method will be used. The `ResponseTypeFunc` function returns an instance of the response structure defined above, or `nil` if there is no response type.
+1. Implement the `APICall` interface for the command. The `URLPathFunc` argument makes use of the Name and Resource Group Name attributes to construct a URL, and the `APIInfo` method determines the HTTP Method will be used. The `ResponseTypeFunc` function returns an instance of the response structure defined above, or `nil` if there is no response type.
 
-        func (s CreateOrUpdateServer) ApiInfo() azure.ApiInfo {
-            return azure.ApiInfo{
-                ApiVersion:  apiVersion,
+        func (s CreateOrUpdateServer) APIInfo() azure.APIInfo {
+            return azure.APIInfo{
+                APIVersion:  apiVersion,
                 Method:      "PUT",
                 URLPathFunc: sqlServerDefaultURLPath(s.ResourceGroupName, s.Name),
                 ResponseTypeFunc: func() interface{} {

--- a/azure/apicall.go
+++ b/azure/apicall.go
@@ -1,17 +1,17 @@
 package azure
 
-// ApiCall must be implemented by structures which represent requests to the
+// APICall must be implemented by structures which represent requests to the
 // ARM API in order that the generic request handling layer has sufficient
 // information to execute requests.
-type ApiCall interface {
-	ApiInfo() ApiInfo
+type APICall interface {
+	APIInfo() APIInfo
 }
 
-// ApiInfo contains information about a request to the ARM API - which API
+// APIInfo contains information about a request to the ARM API - which API
 // version is required, the HTTP method to use, and a factory function for
 // responses.
-type ApiInfo struct {
-	ApiVersion       string
+type APIInfo struct {
+	APIVersion       string
 	Method           string
 	URLPathFunc      func() string
 	ResponseTypeFunc func() interface{}
@@ -20,6 +20,6 @@ type ApiInfo struct {
 // HasBody returns true if the API Request should have a body. This is usually
 // the case for PUT, PATCH or POST operations, but is not the case for GET operations.
 // TODO(jen20): This may need revisiting at some point.
-func (apiInfo ApiInfo) HasBody() bool {
+func (apiInfo APIInfo) HasBody() bool {
 	return apiInfo.Method == "POST" || apiInfo.Method == "PUT" || apiInfo.Method == "PATCH"
 }

--- a/azure/create_resource_group.go
+++ b/azure/create_resource_group.go
@@ -13,9 +13,9 @@ type CreateResourceGroup struct {
 	Tags     map[string]*string `json:"-" riviera:"tags"`
 }
 
-func (command CreateResourceGroup) ApiInfo() ApiInfo {
-	return ApiInfo{
-		ApiVersion:  resourceGroupAPIVersion,
+func (command CreateResourceGroup) APIInfo() APIInfo {
+	return APIInfo{
+		APIVersion:  resourceGroupAPIVersion,
 		Method:      "PUT",
 		URLPathFunc: resourceGroupDefaultURLFunc(command.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/azure/delete_resource_group.go
+++ b/azure/delete_resource_group.go
@@ -4,9 +4,9 @@ type DeleteResourceGroup struct {
 	Name string `json:"-"`
 }
 
-func (s DeleteResourceGroup) ApiInfo() ApiInfo {
-	return ApiInfo{
-		ApiVersion:  resourceGroupAPIVersion,
+func (s DeleteResourceGroup) APIInfo() APIInfo {
+	return APIInfo{
+		APIVersion:  resourceGroupAPIVersion,
 		Method:      "DELETE",
 		URLPathFunc: resourceGroupDefaultURLFunc(s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/azure/register_resource_provider.go
+++ b/azure/register_resource_provider.go
@@ -14,9 +14,9 @@ type RegisterResourceProvider struct {
 	Namespace string `json:"-"`
 }
 
-func (command RegisterResourceProvider) ApiInfo() ApiInfo {
-	return ApiInfo{
-		ApiVersion: resourceGroupAPIVersion,
+func (command RegisterResourceProvider) APIInfo() APIInfo {
+	return APIInfo{
+		APIVersion: resourceGroupAPIVersion,
 		Method:     "POST",
 		URLPathFunc: func() string {
 			return fmt.Sprintf("providers/%s/register", command.Namespace)

--- a/azure/request.go
+++ b/azure/request.go
@@ -16,11 +16,11 @@ import (
 )
 
 type Request struct {
-	URI      *string             `json:"-"`
-	location *string             `json:"location,omitempty"`
-	tags     *map[string]*string `json:"tags,omitempty"`
-	etag     *string             `json:"etag,omitempty"`
-	Command  ApiCall             `json:"properties,omitempty"`
+	URI      *string
+	location *string
+	tags     *map[string]*string
+	etag     *string
+	Command  APICall
 
 	client *Client
 }
@@ -107,7 +107,7 @@ func (request *Request) pollForAsynchronousResponse(acceptedResponse *http.Respo
 }
 
 func (r *Request) Execute() (*Response, error) {
-	apiInfo := r.Command.ApiInfo()
+	apiInfo := r.Command.APIInfo()
 
 	var urlString string
 
@@ -157,7 +157,7 @@ func (r *Request) Execute() (*Response, error) {
 	}
 
 	query := req.URL.Query()
-	query.Set("api-version", apiInfo.ApiVersion)
+	query.Set("api-version", apiInfo.APIVersion)
 	req.URL.RawQuery = query.Encode()
 
 	if apiInfo.HasBody() {

--- a/dns/create_dns_zone.go
+++ b/dns/create_dns_zone.go
@@ -9,9 +9,9 @@ type CreateDNSZone struct {
 	Tags              map[string]*string `json:"-" riviera:"tags"`
 }
 
-func (command CreateDNSZone) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (command CreateDNSZone) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PUT",
 		URLPathFunc: dnsZoneDefaultURLPathFunc(command.ResourceGroupName, command.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/dns/delete_dns_zone.go
+++ b/dns/delete_dns_zone.go
@@ -7,9 +7,9 @@ type DeleteDNSZone struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (command DeleteDNSZone) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (command DeleteDNSZone) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "DELETE",
 		URLPathFunc: dnsZoneDefaultURLPathFunc(command.ResourceGroupName, command.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/dns/get_dns_zone.go
+++ b/dns/get_dns_zone.go
@@ -16,9 +16,9 @@ type GetDNSZone struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (s GetDNSZone) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s GetDNSZone) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "GET",
 		URLPathFunc: dnsZoneDefaultURLPathFunc(s.ResourceGroupName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/examples/resourcegroup/main.go
+++ b/examples/resourcegroup/main.go
@@ -51,7 +51,7 @@ func main() {
 		fmt.Printf("\tLocation: %s\n", *result.Location)
 		fmt.Printf("\tProvisioningState: %s\n", *result.ProvisioningState)
 	} else {
-		log.Fatal("Failed creating resource group: %s", response.Error.Error())
+		log.Fatalf("Failed creating resource group: %s", response.Error.Error())
 	}
 
 	// 6 - Delete the resource group

--- a/sql/create_elastic_database_pool.go
+++ b/sql/create_elastic_database_pool.go
@@ -15,9 +15,9 @@ type CreateElasticDatabasePool struct {
 	DatabaseDTUMax    *string            `json:"databaseDtuMax,omitempty"`
 }
 
-func (s CreateElasticDatabasePool) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s CreateElasticDatabasePool) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PUT",
 		URLPathFunc: sqlElasticPoolDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/create_or_update_database.go
+++ b/sql/create_or_update_database.go
@@ -37,9 +37,9 @@ type CreateOrUpdateDatabase struct {
 	ElasticPoolName               *string            `json:"elasticPoolName,omitempty"`
 }
 
-func (s CreateOrUpdateDatabase) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s CreateOrUpdateDatabase) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PUT",
 		URLPathFunc: sqlDatabaseDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/create_or_update_firewall_rule.go
+++ b/sql/create_or_update_firewall_rule.go
@@ -18,9 +18,9 @@ type CreateOrUpdateFirewallRule struct {
 	EndIpAddress      *string `json:"endIpAddress,omitempty"`
 }
 
-func (s CreateOrUpdateFirewallRule) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s CreateOrUpdateFirewallRule) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PUT",
 		URLPathFunc: sqlServerFirewallDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/create_or_update_server.go
+++ b/sql/create_or_update_server.go
@@ -27,9 +27,9 @@ type CreateOrUpdateServer struct {
 	Version                    *string            `json:"version,omitempty"`
 }
 
-func (s CreateOrUpdateServer) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s CreateOrUpdateServer) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PUT",
 		URLPathFunc: sqlServerDefaultURLPath(s.ResourceGroupName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/delete_database.go
+++ b/sql/delete_database.go
@@ -8,9 +8,9 @@ type DeleteDatabase struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (s DeleteDatabase) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s DeleteDatabase) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "DELETE",
 		URLPathFunc: sqlDatabaseDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/delete_elastic_database_pool.go
+++ b/sql/delete_elastic_database_pool.go
@@ -8,9 +8,9 @@ type DeleteElasticDatabasePool struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (s DeleteElasticDatabasePool) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s DeleteElasticDatabasePool) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "DELETE",
 		URLPathFunc: sqlElasticPoolDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/delete_firewall_rule.go
+++ b/sql/delete_firewall_rule.go
@@ -8,9 +8,9 @@ type DeleteFirewallRule struct {
 	ServerName        string `json:"-"`
 }
 
-func (s DeleteFirewallRule) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s DeleteFirewallRule) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "DELETE",
 		URLPathFunc: sqlServerFirewallDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/delete_server.go
+++ b/sql/delete_server.go
@@ -7,9 +7,9 @@ type DeleteServer struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (s DeleteServer) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s DeleteServer) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "DELETE",
 		URLPathFunc: sqlServerDefaultURLPath(s.ResourceGroupName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/get_database.go
+++ b/sql/get_database.go
@@ -25,9 +25,9 @@ type GetDatabase struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (s GetDatabase) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s GetDatabase) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "GET",
 		URLPathFunc: sqlDatabaseDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/get_firewall_rule.go
+++ b/sql/get_firewall_rule.go
@@ -16,9 +16,9 @@ type GetFirewallRule struct {
 	ServerName        string `json:"-"`
 }
 
-func (s GetFirewallRule) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s GetFirewallRule) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "GET",
 		URLPathFunc: sqlServerFirewallDefaultURLPath(s.ResourceGroupName, s.ServerName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/sql/get_server.go
+++ b/sql/get_server.go
@@ -22,9 +22,9 @@ type GetServer struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (s GetServer) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s GetServer) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "GET",
 		URLPathFunc: sqlServerDefaultURLPath(s.ResourceGroupName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/storage/create_storage_account.go
+++ b/storage/create_storage_account.go
@@ -15,9 +15,9 @@ type CreateStorageAccount struct {
 	Tags              map[string]*string `json:"-" riviera:"tags"`
 }
 
-func (s CreateStorageAccount) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s CreateStorageAccount) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PUT",
 		URLPathFunc: storageDefaultURLPathFunc(s.ResourceGroupName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/storage/delete_storage_account.go
+++ b/storage/delete_storage_account.go
@@ -7,9 +7,9 @@ type DeleteStorageAccount struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (command DeleteStorageAccount) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (command DeleteStorageAccount) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "DELETE",
 		URLPathFunc: storageDefaultURLPathFunc(command.ResourceGroupName, command.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/storage/get_storage_account_properties.go
+++ b/storage/get_storage_account_properties.go
@@ -17,7 +17,7 @@ type GetStorageAccountPropertiesResponse struct {
 	StatusOfPrimary     *string `mapstructure:"statusOfPrimary"`
 	LastGeoFailoverTime *string `mapstructure:"lastGeoFailoverTime"`
 	SecondaryLocation   *string `mapstructure:"secondaryLocation"`
-	StatusOfSecondary   *string `mapstructure:statusOfSecondary"`
+	StatusOfSecondary   *string `mapstructure:"statusOfSecondary"`
 	SecondaryEndpoints  *struct {
 		Blob  *string `mapstructure:"blob"`
 		Queue *string `mapstructure:"queue"`
@@ -34,9 +34,9 @@ type GetStorageAccountProperties struct {
 	ResourceGroupName string `json:"-"`
 }
 
-func (s GetStorageAccountProperties) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (s GetStorageAccountProperties) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "GET",
 		URLPathFunc: storageDefaultURLPathFunc(s.ResourceGroupName, s.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/storage/update_storage_account_custom_domain.go
+++ b/storage/update_storage_account_custom_domain.go
@@ -17,9 +17,9 @@ type UpdateStorageAccountCustomDomain struct {
 	CustomDomain      CustomDomain `json:"customDomain"`
 }
 
-func (command UpdateStorageAccountCustomDomain) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (command UpdateStorageAccountCustomDomain) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PATCH",
 		URLPathFunc: storageDefaultURLPathFunc(command.ResourceGroupName, command.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/storage/update_storage_account_tags.go
+++ b/storage/update_storage_account_tags.go
@@ -12,9 +12,9 @@ type UpdateStorageAccountTags struct {
 	Tags              map[string]*string `json:"-" riviera:"tags"`
 }
 
-func (command UpdateStorageAccountTags) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (command UpdateStorageAccountTags) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PATCH",
 		URLPathFunc: storageDefaultURLPathFunc(command.ResourceGroupName, command.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/storage/update_storage_account_type.go
+++ b/storage/update_storage_account_type.go
@@ -12,9 +12,9 @@ type UpdateStorageAccountType struct {
 	AccountType       *string `json:"accountType,omitempty"`
 }
 
-func (command UpdateStorageAccountType) ApiInfo() azure.ApiInfo {
-	return azure.ApiInfo{
-		ApiVersion:  apiVersion,
+func (command UpdateStorageAccountType) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
 		Method:      "PATCH",
 		URLPathFunc: storageDefaultURLPathFunc(command.ResourceGroupName, command.Name),
 		ResponseTypeFunc: func() interface{} {

--- a/test/runner.go
+++ b/test/runner.go
@@ -60,7 +60,7 @@ func Test(t *testing.T, c TestCase) {
 	log.Println("[INFO] Creating Azure Client...")
 	azureClient, err := azure.NewClient(creds)
 	if err != nil {
-		t.Fatal("Error creating Azure Client: %s", err)
+		t.Fatalf("Error creating Azure Client: %s", err)
 	}
 
 	state := &basicAzureStateBag{

--- a/test/step_run_command.go
+++ b/test/step_run_command.go
@@ -7,9 +7,9 @@ import (
 )
 
 type StepRunCommand struct {
-	RunCommand     azure.ApiCall
-	CleanupCommand azure.ApiCall
-	StateCommand   azure.ApiCall
+	RunCommand     azure.APICall
+	CleanupCommand azure.APICall
+	StateCommand   azure.APICall
 	StateBagKey    string
 }
 


### PR DESCRIPTION
This fixes issues with `go lint` and `go vet`, except for missing comments on exported structures and methods.
