### PR TITLE
test: Make tests use abdullin/seq library

### DIFF
--- a/dns/dns_acceptance_test.go
+++ b/dns/dns_acceptance_test.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"testing"
 
+	"github.com/abdullin/seq"
 	"github.com/jen20/riviera/azure"
 	"github.com/jen20/riviera/test"
 )
@@ -40,9 +41,10 @@ func TestAccCreateDnsZone(t *testing.T) {
 				},
 			},
 			&test.StepAssert{
-				Checks: []test.AssertFunc{
-					test.CheckStringProperty("dnszone", "Name", zoneName),
-					test.CheckStringProperty("dnszone", "NumberOfRecordSets", "2"),
+				StateBagKey: "dnszone",
+				Assertions: seq.Map{
+					"Name":               zoneName,
+					"NumberOfRecordSets": 2,
 				},
 			},
 		},
@@ -112,8 +114,13 @@ func TestAccCreateDnsARecordSet(t *testing.T) {
 				},
 			},
 			&test.StepAssert{
-				Checks: []test.AssertFunc{
-					test.CheckIntProperty("dnsrecordset", "TTL", 300),
+				StateBagKey: "dnsrecordset",
+				Assertions: seq.Map{
+					"TTL":                     300,
+					"Name":                    recordSetName,
+					"Location":                azure.Global,
+					"ARecords[0].ipv4Address": "10.0.10.1",
+					"ARecords[1].ipv4Address": "10.0.10.2",
 				},
 			},
 		},

--- a/test/resource_group_acceptance_test.go
+++ b/test/resource_group_acceptance_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"testing"
 
+	"github.com/abdullin/seq"
 	"github.com/jen20/riviera/azure"
 )
 
@@ -16,9 +17,10 @@ func TestAccCreateResourceGroup(t *testing.T) {
 				Location: azure.WestUS,
 			},
 			&StepAssert{
-				Checks: []AssertFunc{
-					CheckStringProperty("resourcegroup", "Name", rgName),
-					CheckStringProperty("resourcegroup", "Location", azure.WestUS),
+				StateBagKey: "resourcegroup",
+				Assertions: seq.Map{
+					"Name":     rgName,
+					"Location": azure.WestUS,
 				},
 			},
 		},


### PR DESCRIPTION
This removes some (monstrous) homegrown reflection in favour of using Rinat's Seq library for asserting against responses in acceptance tests. This adds support for nested structures using "Object path" notation (e.g. `"StorageAccount.PrimaryEndpoint.Queue" == "helloworld"`, and `"ARecords[0].ipv4Address" == "10.1.1.1"`).

The only oddity right now is that if types have JSON tagging on them, the JSON tag names must be used in the assertion paths and not the field names (technically it is always using the JSON tags, but the default naming means that by default these match the field names in the struct).
