### PR TITLE
Support arbitrary envelope fields in requests

### DIFF
--- a/azure/request.go
+++ b/azure/request.go
@@ -26,39 +26,25 @@ type Request struct {
 	client *Client
 }
 
-func readLocation(req interface{}) (string, bool) {
+func readTaggedFields(command interface{}) map[string]interface{} {
 	var value reflect.Value
-	if reflect.ValueOf(req).Kind() == reflect.Ptr {
-		value = reflect.ValueOf(req).Elem()
+	if reflect.ValueOf(command).Kind() == reflect.Ptr {
+		value = reflect.ValueOf(command).Elem()
 	} else {
-		value = reflect.ValueOf(req)
+		value = reflect.ValueOf(command)
 	}
+
+	result := make(map[string]interface{})
 
 	for i := 0; i < value.NumField(); i++ { // iterates through every struct type field
+		fmt.Println(i, value.Type().Field(i).Name)
 		tag := value.Type().Field(i).Tag // returns the tag string
-		if tag.Get("riviera") == "location" {
-			return value.Field(i).String(), true
+		tagValue := tag.Get("riviera")
+		if tagValue != "" {
+			result[tagValue] = value.Field(i).Interface()
 		}
 	}
-	return "", false
-}
-
-func readTags(req interface{}) (map[string]*string, bool) {
-	var value reflect.Value
-	if reflect.ValueOf(req).Kind() == reflect.Ptr {
-		value = reflect.ValueOf(req).Elem()
-	} else {
-		value = reflect.ValueOf(req)
-	}
-
-	for i := 0; i < value.NumField(); i++ { // iterates through every struct type field
-		tag := value.Type().Field(i).Tag // returns the tag string
-		if tag.Get("riviera") == "tags" {
-			tags := value.Field(i)
-			return tags.Interface().(map[string]*string), true
-		}
-	}
-	return make(map[string]*string), false
+	return result
 }
 
 func (request *Request) pollForAsynchronousResponse(acceptedResponse *http.Response) (*http.Response, error) {
@@ -108,24 +94,15 @@ func (request *Request) pollForAsynchronousResponse(acceptedResponse *http.Respo
 }
 
 func defaultARMRequestStruct(request *Request, properties interface{}) interface{} {
-	bodyStruct := struct {
-		Location   *string             `json:"location,omitempty"`
-		Tags       *map[string]*string `json:"tags,omitempty"`
-		Properties interface{}         `json:"properties"`
-	}{
-		Properties: properties,
+	body := make(map[string]interface{})
+
+	envelopeFields := readTaggedFields(properties)
+	for k, v := range envelopeFields {
+		body[k] = v
 	}
 
-	if location, hasLocation := readLocation(request.Command); hasLocation {
-		bodyStruct.Location = &location
-	}
-	if tags, hasTags := readTags(request.Command); hasTags {
-		if len(tags) > 0 {
-			bodyStruct.Tags = &tags
-		}
-	}
-
-	return bodyStruct
+	body["properties"] = properties
+	return body
 }
 
 func defaultARMRequestSerialize(body interface{}) (io.ReadSeeker, error) {
@@ -162,6 +139,7 @@ func (request *Request) Execute() (*Response, error) {
 		} else {
 			bodyStruct = defaultARMRequestStruct(request, request.Command)
 		}
+
 		serialized, err := defaultARMRequestSerialize(bodyStruct)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This adds support for fields other than "tags" and "location" by looking for any fields tagged with "riviera" and adding them to the request.

@stack72 could you review this?
