### PR TITLE
added failover sql support

### DIFF
--- a/azure/apicall.go
+++ b/azure/apicall.go
@@ -16,11 +16,15 @@ type APIInfo struct {
 	URLPathFunc           func() string
 	ResponseTypeFunc      func() interface{}
 	RequestPropertiesFunc func() interface{}
+	HasBodyOverride       bool
 }
 
 // HasBody returns true if the API Request should have a body. This is usually
 // the case for PUT, PATCH or POST operations, but is not the case for GET operations.
 // TODO(jen20): This may need revisiting at some point.
 func (apiInfo APIInfo) HasBody() bool {
-	return apiInfo.Method == "POST" || apiInfo.Method == "PUT" || apiInfo.Method == "PATCH"
+	if apiInfo.HasBodyOverride == false {
+		return apiInfo.Method == "POST" || apiInfo.Method == "PUT" || apiInfo.Method == "PATCH"
+	}
+	return !(apiInfo.Method == "POST" || apiInfo.Method == "PUT" || apiInfo.Method == "PATCH")
 }

--- a/sql/api.go
+++ b/sql/api.go
@@ -23,6 +23,12 @@ func sqlDatabaseDefaultURLPath(resourceGroupName, serverName, databaseName strin
 	}
 }
 
+func sqlDatabaseFailoverUnplanned(resourceGroupName, serverName, databaseName, linkID string) func() string {
+	return func() string {
+		return fmt.Sprintf("resourcegroups/%s/providers/%s/servers/%s/databases/%s/replicationLinks/%s/forceFailoverAllowDataLoss", resourceGroupName, apiProvider, serverName, databaseName, linkID)
+	}
+}
+
 func sqlServerFirewallDefaultURLPath(resourceGroupName, serverName, firewallRuleName string) func() string {
 	return func() string {
 		return fmt.Sprintf("resourceGroups/%s/providers/%s/servers/%s/firewallRules/%s", resourceGroupName, apiProvider, serverName, firewallRuleName)

--- a/sql/failover_database.go
+++ b/sql/failover_database.go
@@ -1,0 +1,22 @@
+package sql
+
+import "github.com/jen20/riviera/azure"
+
+type FailoverDatabase struct {
+	DatabaseName      string `json:"-"`
+	ServerName        string `json:"-"`
+	ResourceGroupName string `json:"-"`
+	LinkID            string `json:"-"`
+}
+
+func (s FailoverDatabase) APIInfo() azure.APIInfo {
+	return azure.APIInfo{
+		APIVersion:  apiVersion,
+		Method:      "POST",
+		URLPathFunc: sqlDatabaseFailoverUnplanned(s.ResourceGroupName, s.ServerName, s.DatabaseName, s.LinkID),
+		ResponseTypeFunc: func() interface{} {
+			return nil
+		},
+		HasBodyOverride: true,
+	}
+}


### PR DESCRIPTION
Hey James, 

I added support for issuing failover commands to SQL databases. This was a little tricky as it's a POST request, but has no body. If you try to send a body it fails. I have a feeling there are other Azure requests similar to this unfortunately.

I did the least intrusive change I could think of and added a `HasBodyOverride` optional field on the APIInfo struct that will just invert current logic. A better solution might be to add `HasBody` as a field in APIInfo? Not sure what you prefer. 

Thanks - Andrew
