### PR TITLE
Support for different Azure environments

### DIFF
--- a/azure/client.go
+++ b/azure/client.go
@@ -4,8 +4,9 @@ import (
 	"io/ioutil"
 	"log"
 
-	"github.com/hashicorp/go-retryablehttp"
 	"net/http"
+
+	"github.com/hashicorp/go-retryablehttp"
 )
 
 type Client struct {
@@ -24,10 +25,12 @@ func NewClient(creds *AzureResourceManagerCredentials) (*Client, error) {
 	httpClient := retryablehttp.NewClient()
 	httpClient.Logger = defaultLogger
 
-	tr := newTokenRequester(httpClient, creds.ClientID, creds.ClientSecret, creds.TenantID)
+	endpoints := GetEndpoints(creds.Environment)
+
+	tr := newTokenRequester(httpClient, creds.ClientID, creds.ClientSecret, creds.TenantID, endpoints)
 
 	return &Client{
-		BaseURL:        "https://management.azure.com",
+		BaseURL:        endpoints.resourceManagerEndpointUrl,
 		subscriptionID: creds.SubscriptionID,
 		httpClient:     httpClient,
 		tokenRequester: tr,
@@ -35,7 +38,7 @@ func NewClient(creds *AzureResourceManagerCredentials) (*Client, error) {
 	}, nil
 }
 
-func (c *Client) SetRequestLoggingHook(hook func (*log.Logger, *http.Request, int)) {
+func (c *Client) SetRequestLoggingHook(hook func(*log.Logger, *http.Request, int)) {
 	c.httpClient.RequestLogHook = hook
 }
 

--- a/azure/credentials.go
+++ b/azure/credentials.go
@@ -5,4 +5,5 @@ type AzureResourceManagerCredentials struct {
 	ClientSecret   string
 	TenantID       string
 	SubscriptionID string
+	Environment    environment
 }

--- a/azure/environments.go
+++ b/azure/environments.go
@@ -5,6 +5,8 @@ type environment int64
 const (
 	AzureCloud environment = iota
 	AzureGermanCloud
+	AzureChinaCloud
+	AzureUSGovernment
 )
 
 type Endpoint struct {
@@ -15,8 +17,12 @@ type Endpoint struct {
 var environments = []Endpoint{
 	// AzureCloud
 	{"https://management.azure.com", "https://login.microsoftonline.com"},
-	// GermanCloud
+	// AzureGermanCloud
 	{"https://management.microsoftazure.de", "https://login.microsoftonline.de"},
+	// AzureChinaCloud
+	{"https://management.chinacloudapi.cn", "https://login.chinacloudapi.cn"},
+	// AzureUSGovernment
+	{"https://management.usgovcloudapi.net", "https://login.microsoftonline.com"},
 }
 
 func GetEndpoints(e environment) Endpoint {

--- a/azure/environments.go
+++ b/azure/environments.go
@@ -9,12 +9,12 @@ const (
 	AzureUSGovernment
 )
 
-type Endpoint struct {
+type Endpoints struct {
 	resourceManagerEndpointUrl string
 	activeDirectoryEndpointUrl string
 }
 
-var environments = []Endpoint{
+var environments = []Endpoints{
 	// AzureCloud
 	{"https://management.azure.com", "https://login.microsoftonline.com"},
 	// AzureGermanCloud
@@ -25,6 +25,25 @@ var environments = []Endpoint{
 	{"https://management.usgovcloudapi.net", "https://login.microsoftonline.com"},
 }
 
-func GetEndpoints(e environment) Endpoint {
+func StringToEnvironment(str string) environment {
+	var env environment
+
+	switch str {
+	case "AzureCloud":
+		env = AzureCloud
+	case "AzureGermanCloud":
+		env = AzureGermanCloud
+	case "AzureChinaCloud":
+		env = AzureChinaCloud
+	case "AzuerUSGovernment":
+		env = AzureUSGovernment
+	default:
+		env = AzureCloud
+	}
+
+	return env
+}
+
+func GetEndpoints(e environment) Endpoints {
 	return environments[e]
 }

--- a/azure/environments.go
+++ b/azure/environments.go
@@ -1,0 +1,24 @@
+package azure
+
+type environment int64
+
+const (
+	AzureCloud environment = iota
+	AzureGermanCloud
+)
+
+type Endpoint struct {
+	resourceManagerEndpointUrl string
+	activeDirectoryEndpointUrl string
+}
+
+var environments = []Endpoint{
+	// AzureCloud
+	{"https://management.azure.com", "https://login.microsoftonline.com"},
+	// GermanCloud
+	{"https://management.microsoftazure.de", "https://login.microsoftonline.de"},
+}
+
+func GetEndpoints(e environment) Endpoint {
+	return environments[e]
+}

--- a/examples/error/main.go
+++ b/examples/error/main.go
@@ -17,6 +17,7 @@ func main() {
 		ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
 		TenantID:       os.Getenv("ARM_TENANT_ID"),
 		SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+		Environment:    azure.StringToEnvironment(os.Getenv("ARM_ENVIRONMENT")),
 	}
 
 	azureClient, err := azure.NewClient(creds)

--- a/examples/resourcegroup/main.go
+++ b/examples/resourcegroup/main.go
@@ -17,6 +17,7 @@ func main() {
 		ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
 		TenantID:       os.Getenv("ARM_TENANT_ID"),
 		SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+		Environment:    azure.StringToEnvironment(os.Getenv("ARM_ENVIRONMENT")),
 	}
 
 	azureClient, err := azure.NewClient(creds)

--- a/examples/sql/main.go
+++ b/examples/sql/main.go
@@ -17,6 +17,7 @@ func main() {
 		ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
 		TenantID:       os.Getenv("ARM_TENANT_ID"),
 		SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+		Environment:    azure.StringToEnvironment(os.Getenv("ARM_ENVIRONMENT")),
 	}
 
 	azureClient, err := azure.NewClient(creds)

--- a/examples/storage/main.go
+++ b/examples/storage/main.go
@@ -18,6 +18,7 @@ func main() {
 		ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
 		TenantID:       os.Getenv("ARM_TENANT_ID"),
 		SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+		Environment:    azure.StringToEnvironment(os.Getenv("ARM_ENVIRONMENT")),
 	}
 
 	azureClient, err := azure.NewClient(creds)

--- a/test/runner.go
+++ b/test/runner.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/jen20/riviera/azure"
 )
 
@@ -38,6 +37,7 @@ func Test(t *testing.T, c TestCase) {
 		ClientSecret:   os.Getenv("ARM_CLIENT_SECRET"),
 		TenantID:       os.Getenv("ARM_TENANT_ID"),
 		SubscriptionID: os.Getenv("ARM_SUBSCRIPTION_ID"),
+		Environment:    azure.StringToEnvironment(os.Getenv("ARM_ENVIRONMENT")),
 	}
 
 	var prerollErrors *multierror.Error
@@ -52,6 +52,9 @@ func Test(t *testing.T, c TestCase) {
 	}
 	if creds.SubscriptionID == "" {
 		prerollErrors = multierror.Append(prerollErrors, fmt.Errorf("The ARM_SUBSCRIPTION_ID environment variable must be set to run acceptance tests"))
+	}
+	if creds.Environment == "" {
+		prerollErrors = multierror.Append(prerollErrors, fmt.Errorf("The ARM_ENVIRONMENT environment variable must be set to run acceptance tests"))
 	}
 	if errs := prerollErrors.ErrorOrNil(); errs != nil {
 		t.Fatal(errs)


### PR DESCRIPTION
This pull request adds support for all four Azure environments:
- AzureCloud
- AzureGermanCloud
- AzureChinaCloud
- AzureUSGovernment

Each of these environments have different endpoints for authentication and resource management (e.g. AzureChinaCloud: `https://management.chinacloudapi.cn, https://login.chinacloudapi.cn`).

The environment can be specified via environment variable `ARM_ENVIRONMENT`. Default is `AzureCloud`if no environment variable is set.
