### PR TITLE
Support for name and display name format of location parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ vendor/
 .idea
 *.test
 *.iml
+.vscode

--- a/azure/endpoints.go
+++ b/azure/endpoints.go
@@ -1,5 +1,7 @@
 package azure
 
+import "strings"
+
 type Endpoints struct {
 	resourceManagerEndpointUrl string
 	activeDirectoryEndpointUrl string
@@ -8,15 +10,14 @@ type Endpoints struct {
 func GetEndpoints(location string) Endpoints {
 	var e Endpoints
 
+	location = strings.Replace(strings.ToLower(location), " ", "", -1)
+
 	switch location {
-	case GermanyCentral:
-	case GermanyEast:
+	case GermanyCentral, GermanyEast:
 		e = Endpoints{"https://management.microsoftazure.de", "https://login.microsoftonline.de"}
-	case ChinaEast:
-	case ChinaNorth:
+	case ChinaEast, ChinaNorth:
 		e = Endpoints{"https://management.chinacloudapi.cn", "https://login.chinacloudapi.cn"}
-	case USGovIowa:
-	case USGovVirginia:
+	case USGovIowa, USGovVirginia:
 		e = Endpoints{"https://management.usgovcloudapi.net", "https://login.microsoftonline.com"}
 	default:
 		e = Endpoints{"https://management.azure.com", "https://login.microsoftonline.com"}


### PR DESCRIPTION
This pull request adds support for both "name" (e.g. northeurope) and "display name" format (e.g. North Europe) location parameters. This is necessary now since we need to support both versions when choosing the correct authentication and management endpoints.
