### PR TITLE
azure: fix panic for commands with no Location field

### DIFF
--- a/azure/endpoints.go
+++ b/azure/endpoints.go
@@ -1,27 +1,43 @@
 package azure
 
-import "strings"
+import (
+	"reflect"
+	"strings"
+)
 
 type Endpoints struct {
 	resourceManagerEndpointUrl string
 	activeDirectoryEndpointUrl string
 }
 
-func GetEndpoints(location string) Endpoints {
-	var e Endpoints
+var (
+	ChineseEndpoints = Endpoints{"https://management.chinacloudapi.cn", "https://login.chinacloudapi.cn"}
+	DefaultEndpoints = Endpoints{"https://management.azure.com", "https://login.microsoftonline.com"}
+	GermanEndpoints  = Endpoints{"https://management.microsoftazure.de", "https://login.microsoftonline.de"}
+	USGovEndpoints   = Endpoints{"https://management.usgovcloudapi.net", "https://login.microsoftonline.com"}
+)
 
+func GetEndpointsForLocation(location string) Endpoints {
 	location = strings.Replace(strings.ToLower(location), " ", "", -1)
 
 	switch location {
 	case GermanyCentral, GermanyEast:
-		e = Endpoints{"https://management.microsoftazure.de", "https://login.microsoftonline.de"}
+		return GermanEndpoints
 	case ChinaEast, ChinaNorth:
-		e = Endpoints{"https://management.chinacloudapi.cn", "https://login.chinacloudapi.cn"}
+		return ChineseEndpoints
 	case USGovIowa, USGovVirginia:
-		e = Endpoints{"https://management.usgovcloudapi.net", "https://login.microsoftonline.com"}
+		return USGovEndpoints
 	default:
-		e = Endpoints{"https://management.azure.com", "https://login.microsoftonline.com"}
+		return DefaultEndpoints
+	}
+}
+
+func GetEndpointsForCommand(command APICall) Endpoints {
+	locationField := reflect.Indirect(reflect.ValueOf(command)).FieldByName("Location")
+	if locationField.IsValid() {
+		location := locationField.Interface().(string)
+		return GetEndpointsForLocation(location)
 	}
 
-	return e
+	return DefaultEndpoints
 }

--- a/azure/request.go
+++ b/azure/request.go
@@ -75,8 +75,8 @@ func (request *Request) pollForAsynchronousResponse(acceptedResponse *http.Respo
 			return nil, err
 		}
 
-		location := reflect.Indirect(reflect.ValueOf(request.Command)).FieldByName("Location").Interface().(string)
-		err = request.client.tokenRequester.addAuthorizationToRequest(req, location)
+		endpoints := GetEndpointsForCommand(request.Command)
+		err = request.client.tokenRequester.addAuthorizationToRequest(req, endpoints)
 		if err != nil {
 			return nil, err
 		}
@@ -116,11 +116,11 @@ func defaultARMRequestSerialize(body interface{}) (io.ReadSeeker, error) {
 func (request *Request) Execute() (*Response, error) {
 	apiInfo := request.Command.APIInfo()
 
-	location := reflect.Indirect(reflect.ValueOf(request.Command)).FieldByName("Location").Interface().(string)
+	endpoints := GetEndpointsForCommand(request.Command)
 
 	var urlString string
 
-	urlObj, _ := url.Parse(GetEndpoints(location).resourceManagerEndpointUrl)
+	urlObj, _ := url.Parse(endpoints.resourceManagerEndpointUrl)
 
 	// Determine whether to use the URLPathFunc or the URI explicitly set in the request
 	if request.URI == nil {
@@ -166,7 +166,7 @@ func (request *Request) Execute() (*Response, error) {
 		req.Header.Add("Content-Type", "application/json")
 	}
 
-	err = request.client.tokenRequester.addAuthorizationToRequest(req, location)
+	err = request.client.tokenRequester.addAuthorizationToRequest(req, endpoints)
 	if err != nil {
 		return nil, err
 	}

--- a/azure/token.go
+++ b/azure/token.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,8 +44,8 @@ func newTokenRequester(client *retryablehttp.Client, clientID, clientSecret, ten
 // addAuthorizationToRequest adds an Authorization header to an http.Request, having ensured
 // that the token is sufficiently fresh. This may invoke network calls, so should not be
 // relied on to return quickly.
-func (tr *tokenRequester) addAuthorizationToRequest(request *retryablehttp.Request, location string) error {
-	token, err := tr.getUsableToken(location)
+func (tr *tokenRequester) addAuthorizationToRequest(request *retryablehttp.Request, endpoints Endpoints) error {
+	token, err := tr.getUsableToken(endpoints)
 	if err != nil {
 		return fmt.Errorf("Error obtaining authorization token: %s", err)
 	}
@@ -53,7 +54,7 @@ func (tr *tokenRequester) addAuthorizationToRequest(request *retryablehttp.Reque
 	return nil
 }
 
-func (tr *tokenRequester) getUsableToken(location string) (*token, error) {
+func (tr *tokenRequester) getUsableToken(endpoints Endpoints) (*token, error) {
 	tr.l.Lock()
 	defer tr.l.Unlock()
 
@@ -61,7 +62,7 @@ func (tr *tokenRequester) getUsableToken(location string) (*token, error) {
 		return tr.currentToken, nil
 	}
 
-	newToken, err := tr.refreshToken(location)
+	newToken, err := tr.refreshToken(endpoints)
 	if err != nil {
 		return nil, fmt.Errorf("Error refreshing token: %s", err)
 	}
@@ -70,15 +71,14 @@ func (tr *tokenRequester) getUsableToken(location string) (*token, error) {
 	return newToken, nil
 }
 
-func (tr *tokenRequester) refreshToken(location string) (*token, error) {
-	endpoints := GetEndpoints(location)
+func (tr *tokenRequester) refreshToken(endpoints Endpoints) (*token, error) {
 	oauthURL := fmt.Sprintf("%s/%s/oauth2/%s?api-version=1.0", endpoints.activeDirectoryEndpointUrl, tr.tenantID, "token")
 
 	v := url.Values{}
 	v.Set("client_id", tr.clientID)
 	v.Set("client_secret", tr.clientSecret)
 	v.Set("grant_type", "client_credentials")
-	v.Set("resource", endpoints.resourceManagerEndpointUrl)
+	v.Set("resource", strings.TrimSuffix(endpoints.resourceManagerEndpointUrl, "/")+"/")
 
 	var newToken token
 	response, err := tr.httpClient.PostForm(oauthURL, v)


### PR DESCRIPTION
PR #16 introduced a panic for commands without a Location field, this change
will instead fallback to the default endpoints if they cannot be infered
from location.

The token resource claim was also missing a trailing slash which prevented token
requests from succeeding.

Tested with a Terraform resource:
```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMDnsARecord_basic -timeout 120m
=== RUN   TestAccAzureRMDnsARecord_basic
--- PASS: TestAccAzureRMDnsARecord_basic (101.83s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	101.897s
```