### PR TITLE
Get Resource Provider Registration State

### DIFF
--- a/azure/get_resource_provider.go
+++ b/azure/get_resource_provider.go
@@ -1,0 +1,29 @@
+package azure
+
+import "fmt"
+
+// SkuName enumerates the values for sku name.
+type RegistrationState string
+
+type GetResourceProviderResponse struct {
+	ID                *string `mapstructure:"id"`
+	Namespace         *string `mapstructure:"namespace"`
+	RegistrationState *string `mapstructure:"registrationState"`
+}
+
+type GetResourceProvider struct {
+	Namespace string `json:"-"`
+}
+
+func (command GetResourceProvider) APIInfo() APIInfo {
+	return APIInfo{
+		APIVersion: resourceGroupAPIVersion,
+		Method:     "GET",
+		URLPathFunc: func() string {
+			return fmt.Sprintf("providers/%s", command.Namespace)
+		},
+		ResponseTypeFunc: func() interface{} {
+			return &GetResourceProviderResponse{}
+		},
+	}
+}

--- a/azure/get_resource_provider.go
+++ b/azure/get_resource_provider.go
@@ -2,9 +2,6 @@ package azure
 
 import "fmt"
 
-// SkuName enumerates the values for sku name.
-type RegistrationState string
-
 type GetResourceProviderResponse struct {
 	ID                *string `mapstructure:"id"`
 	Namespace         *string `mapstructure:"namespace"`

--- a/azure/register_resource_provider.go
+++ b/azure/register_resource_provider.go
@@ -9,7 +9,6 @@ type RegisterResourceProviderResponse struct {
 	ApplicationID     *string `mapstructure:"applicationId"`
 }
 
-// TODO: Investigate RegistrationState response polling
 type RegisterResourceProvider struct {
 	Namespace string `json:"-"`
 }


### PR DESCRIPTION
Exposing [an endpoint](https://docs.microsoft.com/en-us/rest/api/resources/providers) so that it's possible to retrieve the registration state for a particular Resource Provider. This enables us to poll for the registration status when registering - rather than just firing and forgetting (and hitting race conditions where the Provider isn't actually registered)
