### PR TITLE
SQL - moving to a non-preview/LTS API endpoint

### DIFF
--- a/sql/api.go
+++ b/sql/api.go
@@ -2,7 +2,7 @@ package sql
 
 import "fmt"
 
-const apiVersion = "2014-04-01-preview"
+const apiVersion = "2014-04-01"
 const apiProvider = "Microsoft.Sql"
 
 func sqlServerDefaultURLPath(resourceGroupName, serverName string) func() string {


### PR DESCRIPTION
After #24 I've been going through the versions of the API's in Riviera we're using in Terraform.

For SQL - we can simply remove the suffix `prefix` and things continue to work on a supported version. The Terraform tests pass when used in conjunction with this version:

```
$ TF_ACC=1 envchain azurerm go test ./azurerm -v -timeout 120m -run TestAccAzureRMSql
=== RUN   TestAccAzureRMSqlElasticPool_importBasic
--- PASS: TestAccAzureRMSqlElasticPool_importBasic (151.87s)
=== RUN   TestAccAzureRMSqlFirewallRule_importBasic
--- PASS: TestAccAzureRMSqlFirewallRule_importBasic (127.04s)
=== RUN   TestAccAzureRMSqlServer_importBasic
--- PASS: TestAccAzureRMSqlServer_importBasic (97.94s)
=== RUN   TestAccAzureRMSqlDatabase_basic
--- PASS: TestAccAzureRMSqlDatabase_basic (161.94s)
=== RUN   TestAccAzureRMSqlDatabase_elasticPool
--- PASS: TestAccAzureRMSqlDatabase_elasticPool (254.42s)
=== RUN   TestAccAzureRMSqlDatabase_withTags
--- PASS: TestAccAzureRMSqlDatabase_withTags (216.27s)
=== RUN   TestAccAzureRMSqlDatabase_datawarehouse
--- PASS: TestAccAzureRMSqlDatabase_datawarehouse (278.64s)
=== RUN   TestAccAzureRMSqlElasticPool_basic
--- PASS: TestAccAzureRMSqlElasticPool_basic (144.18s)
=== RUN   TestAccAzureRMSqlElasticPool_resizeDtu
--- PASS: TestAccAzureRMSqlElasticPool_resizeDtu (197.29s)
=== RUN   TestAccAzureRMSqlFirewallRule_basic
--- PASS: TestAccAzureRMSqlFirewallRule_basic (155.52s)
=== RUN   TestAccAzureRMSqlServer_basic
--- PASS: TestAccAzureRMSqlServer_basic (96.72s)
=== RUN   TestAccAzureRMSqlServer_withTags
--- PASS: TestAccAzureRMSqlServer_withTags (137.92s)
PASS
ok  	github.com/terraform-providers/terraform-provider-azurerm/azurerm	2019.791s
```